### PR TITLE
Adds `w` and `b` scripts

### DIFF
--- a/.github/linters/.eslintrc.yml
+++ b/.github/linters/.eslintrc.yml
@@ -33,6 +33,7 @@ parserOptions:
 ###########
 plugins:
   - '@typescript-eslint'
+  - import
 
 #########
 # Rules #

--- a/package.json
+++ b/package.json
@@ -2,13 +2,13 @@
   "name": "drupal-ckeditor5",
   "version": "1.0.0",
   "description": "CU Boulder CKEditor 5 Plugin Collection",
-  "author": "",
+  "author": "University of Colorado Boulder",
   "license": "GPL-2.0-or-later",
   "scripts": {
     "watch": "webpack --mode development --watch",
-    "build": "webpack build",
-	"w": "run(){ webpack --mode development --watch --env plugin=\"$1\"; }; run",
-	"b": "run(){ webpack --env plugin=\"$1\"; }; run"
+    "build": "webpack",
+    "w": "run(){ webpack --mode development --watch --env plugin=\"$1\"; }; run",
+    "b": "run(){ webpack --env plugin=\"$1\"; }; run"
   },
   "devDependencies": {
     "@ckeditor/ckeditor5-dev-utils": "^30.0.0",

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   "scripts": {
     "watch": "webpack --mode development --watch",
     "build": "webpack build",
-	"w": "read -p 'Enter a plugin name, or none for all: ' plugin_name; webpack --mode development --watch --env plugin=${plugin_name}",
-	"b": "read -p 'Enter a plugin name, or none for all: ' plugin_name; webpack --env plugin=${plugin_name}"
+	"w": "run(){ webpack --mode development --watch --env plugin=\"$1\"; }; run",
+	"b": "run(){ webpack --env plugin=\"$1\"; }; run"
   },
   "devDependencies": {
     "@ckeditor/ckeditor5-dev-utils": "^30.0.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "license": "GPL-2.0-or-later",
   "scripts": {
     "watch": "webpack --mode development --watch",
-    "build": "webpack"
+    "build": "webpack build",
+	"w": "read -p 'Enter a plugin name, or none for all: ' plugin_name; webpack --mode development --watch --env plugin=${plugin_name}",
+	"b": "read -p 'Enter a plugin name, or none for all: ' plugin_name; webpack --env plugin=${plugin_name}"
   },
   "devDependencies": {
     "@ckeditor/ckeditor5-dev-utils": "^30.0.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,63 +4,64 @@ const webpack = require('webpack');
 const { styles, builds } = require('@ckeditor/ckeditor5-dev-utils');
 const TerserPlugin = require('terser-webpack-plugin');
 
-function getDirectories(srcpath) {
-  return fs
-    .readdirSync(srcpath)
-    .filter((item) => fs.statSync(path.join(srcpath, item)).isDirectory());
+function getDirectories(env, srcpath) {
+	return (env.plugin ? [env.plugin] : fs.readdirSync(srcpath))
+		.filter((item) => fs.statSync(path.join(srcpath, item)).isDirectory());
 }
 
-module.exports = [];
-// Loop through every subdirectory in src, each a different plugin, and build
-// each one in ./build.
-getDirectories('./js/ckeditor5_plugins').forEach((dir) => {
-  const bc = {
-    mode: 'production',
-    optimization: {
-      minimize: true,
-      minimizer: [
-        new TerserPlugin({
-          terserOptions: {
-            format: {
-              comments: false,
-            },
-          },
-          test: /\.js(\?.*)?$/i,
-          extractComments: false,
-        }),
-      ],
-      moduleIds: 'named',
-    },
-    entry: {
-      path: path.resolve(
-        __dirname,
-        'js/ckeditor5_plugins',
-        dir,
-        'src/index.js',
-      ),
-    },
-    output: {
-      path: path.resolve(__dirname, './js/build'),
-      filename: `${dir}.js`,
-      library: ['CKEditor5', dir],
-      libraryTarget: 'umd',
-      libraryExport: 'default',
-    },
-    plugins: [
-      // It is possible to require the ckeditor5-dll.manifest.json used in
-      // core/node_modules rather than having to install CKEditor 5 here.
-      // However, that requires knowing the location of that file relative to
-      // where your module code is located.
-      new webpack.DllReferencePlugin({
-        manifest: require('./node_modules/ckeditor5/build/ckeditor5-dll.manifest.json'), // eslint-disable-line global-require, import/no-unresolved
-        scope: 'ckeditor5/src',
-        name: 'CKEditor5.dll',
-      }),
-    ],
-    module: {
-      rules: [{ test: /\.svg$/, use: 'raw-loader' }],
-    },
-  };
-
-  module.exports.push(bc);
-});
+module.exports = (env) => {
+	const pluginConfigs = [];
+	// Loop through every subdirectory in src, each a different plugin, and build
+	// each one in ./build.
+	getDirectories(env, './js/ckeditor5_plugins').forEach((dir) => {
+		const bc = {
+			mode: 'production',
+			optimization: {
+				minimize: true,
+				minimizer: [
+					new TerserPlugin({
+						terserOptions: {
+							format: {
+								comments: false
+							},
+						},
+						test: /\.js(\?.*)?$/i,
+						extractComments: false
+					})
+				],
+				moduleIds: 'named'
+			},
+			entry: {
+				path: path.resolve(
+					__dirname,
+					'js/ckeditor5_plugins',
+					dir,
+					'src/index.js'
+				)
+			},
+			output: {
+				path: path.resolve(__dirname, './js/build'),
+				filename: `${dir}.js`,
+				library: ['CKEditor5', dir],
+				libraryTarget: 'umd',
+				libraryExport: 'default'
+			},
+			plugins: [
+				// It is possible to require the ckeditor5-dll.manifest.json used in
+				// core/node_modules rather than having to install CKEditor 5 here.
+				// However, that requires knowing the location of that file relative to
+				// where your module code is located.
+				new webpack.DllReferencePlugin({
+					manifest: require('./node_modules/ckeditor5/build/ckeditor5-dll.manifest.json'), // eslint-disable-line global-require, import/no-unresolved
+					scope: 'ckeditor5/src',
+					name: 'CKEditor5.dll'
+				})
+			],
+			module: {
+				rules: [{ test: /\.svg$/, use: 'raw-loader' }]
+			}
+		};
+		pluginConfigs.push(bc);
+	});
+	return pluginConfigs;
+};


### PR DESCRIPTION
Using `w` for `watch` or `b` for `build` allows a command-line argument to specify only а single plugin, e.g. `b box` to build the box plugin. `watch` and `build` function the same as before.

Resolves CuBoulder/ucb_ckeditor_plugins#2