### PR TITLE
Adds CKEditor 5 plugin styles globally to all pages

### DIFF
--- a/ucb_ckeditor_plugins.module
+++ b/ucb_ckeditor_plugins.module
@@ -1,38 +1,49 @@
 <?php
 
 /**
- * Adds plugin styles to pages.
- * Implements hook_preprocess_HOOK().
+ * @file
+ * Contains functional hooks for ucb_ckeditor_plugins.
+ *
+ * Hooks in Drupal typically start with the name of the module, in this case
+ * `ucb_ckeditor_plugins`. Code other than hooks should be put in a PHP class
+ * in the src folder.
+ *
+ * @see https://www.drupal.org/docs/develop/creating-modules/understanding-hooks
  */
-function ucb_ckeditor_plugins_preprocess_field(array &$variables) {
-	$fieldType = $variables['field_type'];
-	if($fieldType == 'text_long' || $fieldType == 'text_with_summary') // Indicates a rich text field
-		$variables['#attached']['library'][] = 'ucb_ckeditor_plugins/ckeditor-plugin-styles';
+
+/**
+ * Adds plugin styles to all pages on the site.
+ *
+ * Implements hook_page_attachments().
+ */
+function ucb_ckeditor_plugins_page_attachments(array &$page) {
+  $page['#attached']['library'][] = 'ucb_ckeditor_plugins/ckeditor-plugin-styles';
 }
 
 /**
- * Exposes embedded templates.
+ * Exposes the needed templates for the map plugin.
+ *
  * Implements hook_theme().
  */
 function ucb_ckeditor_plugins_theme() {
-	return [
-		'ucb_campus_map_embed' => [
-			'variables' => [
-				'attributes' => [],
-				'mapLocation' => ''
-			]
-		],
-		'ucb_google_map_embed' => [
-			'variables' => [
-				'attributes' => [],
-				'mapLocation' => ''
-			]
-		],
-		'ucb_google_calendar_embed' => [
-			'variables' => [
-				'attributes' => [],
-				'queryString' => ''
-			]
-		]
-	];
+  return [
+    'ucb_campus_map_embed' => [
+      'variables' => [
+        'attributes' => [],
+        'mapLocation' => '',
+      ],
+    ],
+    'ucb_google_map_embed' => [
+      'variables' => [
+        'attributes' => [],
+        'mapLocation' => '',
+      ],
+    ],
+    'ucb_google_calendar_embed' => [
+      'variables' => [
+        'attributes' => [],
+        'queryString' => '',
+      ],
+    ],
+  ];
 }


### PR DESCRIPTION
This update:
- [Bug, Meta] Fixes improperly-styled plugin-generated content in the Collection Grid block. Resolves CuBoulder/ucb_ckeditor_plugins#61
- [Bug, Meta] Fixes improperly-styled plugin-generated content in the site footer. 