### PR TITLE
Add margin around buttons

### DIFF
--- a/css/button.css
+++ b/css/button.css
@@ -8,6 +8,7 @@
   padding: 5px 10px;
   font-weight: bold;
   line-height: 1.5em;
+  margin: 3px;
 }
 
 .container > .ucb-button-group{


### PR DESCRIPTION
Resolves https://github.com/CuBoulder/ucb_ckeditor_plugins/issues/99.
Adds some minor padding around each button to allow spacing between buttons.